### PR TITLE
Fix stop timer to cancel pending heartbeat check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ Simply uses the setTimeout for testing a remote document availability via XMLHtt
 
 ## Syntax?
 heartbeat is self explanatory for any junior developer, please take a look to the example.
+

--- a/heartbeat.js
+++ b/heartbeat.js
@@ -34,13 +34,17 @@ class heartbeat{
 	}
 
 
-	stop = function(flag_show){
-		if (this.started)
-		{
-			console.log ("🛑 heartbeat - STOPPED. 🛑");
-			this.started = false;
- 		}
-	}
+        stop = function(flag_show){
+                if (this.started)
+                {
+                        if (this.currenttimeoutID !== null) {
+                                clearTimeout(this.currenttimeoutID);
+                                this.currenttimeoutID = null;
+                        }
+                        console.log ("🛑 heartbeat - STOPPED. 🛑");
+                        this.started = false;
+                }
+        }
 
 	
 	beat = function(flag_show){


### PR DESCRIPTION
## Summary
- cancel the scheduled timeout when `stop()` is called so the heartbeat loop halts immediately
- remove the previously added "Minimal upkeep tips" section from the README to restore the original documentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1840c32d483249436f9c2713459fe